### PR TITLE
Revert 50 feat/amplitude options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,30 +49,6 @@ window.AMPLITUDE_DEV_API_KEY = '<amplitude-dev-api-key>';
 window.AMPLITUDE_PROD_API_KEY = '<amplitude-prod-api-key>';
 ```
 
-If you want to post to the EU endpoint make sure to set the `serverUrl` option:
-
-```ts
-window.AMPLITUDE_OPTIONS = {
-  serverUrl: 'https://api.eu.amplitude.com/2/httpapi',
-};
-```
-
-> Read more: [Configurations](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#configuration), [Endpoints](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#endpoints)
-
-If you are in a typescript project you might want to add the following declarations:
-
-```ts
-declare global {
-  interface Window {
-    AMPLITUDE_DEV_API_KEY: string;
-    AMPLITUDE_PROD_API_KEY: string;
-    AMPLITUDE_OPTIONS: {
-      serverUrl?: string;
-    };
-  }
-}
-```
-
 Now your storybook will begin emitting events to your project in Amplitude. You’re ready to start creating charts in Amplitude!
 
 ## Example Charts

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -3,21 +3,13 @@ import { addons } from "@storybook/addons";
 import { STORY_CHANGED, STORY_ARGS_UPDATED } from "@storybook/core-events";
 import { parsePath } from "../parsePath";
 
-import * as amplitude from "@amplitude/analytics-browser";
+import * as amplitude from "@amplitude/analytics-browser"
 
 addons.register("storybook/amplitude", (api) => {
   if (process.env.NODE_ENV === "production") {
-    amplitude.init(
-      globalWindow.AMPLITUDE_PROD_API_KEY,
-      null,
-      globalWindow.AMPLITUDE_OPTIONS
-    );
+    amplitude.init(globalWindow.AMPLITUDE_PROD_API_KEY);
   } else {
-    amplitude.init(
-      globalWindow.AMPLITUDE_DEV_API_KEY,
-      null,
-      globalWindow.AMPLITUDE_OPTIONS
-    );
+    amplitude.init(globalWindow.AMPLITUDE_DEV_API_KEY);
   }
 
   api.on(STORY_CHANGED, () => {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.1--canary.51.46ece1c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @amplitude/storybook-addon-amplitude@1.1.1--canary.51.46ece1c.0
  # or 
  yarn add @amplitude/storybook-addon-amplitude@1.1.1--canary.51.46ece1c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
