### PR TITLE
SECENG-7700 [security] pinning actions and docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write  # Required for OIDC/Trusted Publishing
       contents: write  # Required for creating releases
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: git fetch --unshallow --tags
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs to prevent supply chain attacks
- Pin Docker base images to digest SHAs where applicable

## Test plan
- [ ] Verify workflows run as expected after pinning